### PR TITLE
レイアウト表示後に処理を行う Mixin の追加

### DIFF
--- a/lib/end_of_frame_listener_mixin.dart
+++ b/lib/end_of_frame_listener_mixin.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+mixin EndOfFrameListenerMixin<T extends StatefulWidget> on State<T> {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(listenEndOfFrame());
+  }
+
+  @protected
+  Future<void> listenEndOfFrame() async {
+    await SchedulerBinding.instance.endOfFrame;
+    onEndOfFrame();
+  }
+
+  @protected
+  void onEndOfFrame();
+}

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
+import 'package:flutter_training/end_of_frame_listener_mixin.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -10,17 +10,16 @@ class SplashScreen extends StatefulWidget {
   State<SplashScreen> createState() => _SplashScreenState();
 }
 
-class _SplashScreenState extends State<SplashScreen> {
+class _SplashScreenState extends State<SplashScreen>
+    with EndOfFrameListenerMixin {
   static const _waitInMillis = 500;
 
   @override
-  void initState() {
-    super.initState();
+  void onEndOfFrame() {
     unawaited(_transition(context));
   }
 
   Future<void> _transition(BuildContext context) async {
-    await SchedulerBinding.instance.endOfFrame;
     await Future<void>.delayed(
       const Duration(milliseconds: _waitInMillis),
     );
@@ -31,10 +30,7 @@ class _SplashScreenState extends State<SplashScreen> {
     // 遷移先から戻るまで待機
     await Navigator.pushNamed(context, '/main');
 
-    if (!context.mounted) {
-      return;
-    }
-    unawaited(_transition(context));
+    unawaited(listenEndOfFrame());
   }
 
   @override


### PR DESCRIPTION
## 課題

close #5 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] レイアウトが表示された後に「何かしらの処理」を行う [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を作成する
- [x] 作成した [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) の使用先で「何かしらの処理」を記述できるようにする
- [x] [Session3](https://github.com/warahiko/flutter-training/issues/4) で作成した以下の処理を作成した [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を使って書き直す
>新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->


https://github.com/warahiko/flutter-training/assets/23146955/c7651607-4e5f-4f9a-8412-9a25f4e83dd7

