### PR TITLE
エラー発生時にダイアログを表示する

### DIFF
--- a/lib/yumemi_weather_error.dart
+++ b/lib/yumemi_weather_error.dart
@@ -1,0 +1,8 @@
+import 'package:yumemi_weather/yumemi_weather.dart';
+
+extension YumemiWeatherErrorExt on YumemiWeatherError {
+  String toMessage() => switch (this) {
+        YumemiWeatherError.invalidParameter => '無効なパラメータです。',
+        YumemiWeatherError.unknown => '不明なエラーです。',
+      };
+}


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の OK ボタンをタップすると、ダイアログを閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| <img src=https://github.com/warahiko/flutter-training/assets/23146955/bf85d45c-c8bd-4369-9318-a4ad0af48374  width=200px>      | <img src=https://github.com/warahiko/flutter-training/assets/23146955/0b0cb288-9ebc-4d27-ab3d-93430cd2fdfd  width=200px>    |



